### PR TITLE
[stageman] Add src/levels.js + lift per-level tunables out of constants.js

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -2,27 +2,8 @@
 // 遊戲常量設定：集中管理難度與時間，方便日後微調
 // ============================================================
 
-// 階段一（搜尋期）點錯背景的冷卻時間（毫秒）
-export const WRONG_CLICK_COOLDOWN = 1500;
-
-// 階段二（追逐期）每次點擊小東西後的短冷卻（毫秒）
-export const CHASE_CLICK_COOLDOWN = 500;
-
-// 追逐期需要命中幾次才能過關
-export const REQUIRED_HITS = 5;
-
-// 整場遊戲的總倒數秒數（失敗判定）
-export const GAME_DURATION = 15;
-
 // 小東西在追逐期移動一次的動畫時間（秒）
 export const CHASE_MOVE_DURATION = 0.55;
-
-// 小東西在追逐期每次自動逃竄的間隔（毫秒）
-export const CHASE_AUTO_MOVE_INTERVAL = 900;
-
-// 小東西尺寸（px）：搜尋期較小、追逐期較大便於點擊
-export const LITTLE_THING_SIZE_SEARCH = 44;
-export const LITTLE_THING_SIZE_CHASE = 72;
 
 // 小東西初始隨機位置的邊距比例（避免貼邊）
 export const SAFE_MARGIN = 0.08;
@@ -43,39 +24,3 @@ export const ASSETS = {
   // 👉 替換為你的個人照片（建議正方形、透明背景或圓形裁切）
   LITTLE_THING: 'https://api.dicebear.com/9.x/fun-emoji/svg?seed=xiaodongxi&backgroundColor=ffdfbf',
 };
-
-// 新增：關卡總數
-export const TOTAL_LEVELS = 3;
-
-// 新增：每關難度設定（index 0 = Level 1）
-// Level 1 的值刻意與檔案上方的單值常量（WRONG_CLICK_COOLDOWN 等）保持一致 —
-// 舊呼叫端先沿用單值常量，新流程改讀 LEVELS[levelIndex]。
-export const LEVELS = [
-  {
-    id: 1, label: '關卡 1 · 暖身',
-    duration: 15, requiredHits: 3,
-    chaseAutoMoveInterval: 900, chaseClickCooldown: 500,
-    wrongClickCooldown: 1500,
-    sizeSearch: 44, sizeChase: 72,
-    decoyCount: 0, decoyAutoMove: false,
-    decoyPenaltyMs: 0,
-  },
-  {
-    id: 2, label: '關卡 2 · 真假難辨',
-    duration: 13, requiredHits: 4,
-    chaseAutoMoveInterval: 700, chaseClickCooldown: 600,
-    wrongClickCooldown: 1800,
-    sizeSearch: 40, sizeChase: 64,
-    decoyCount: 1, decoyAutoMove: false,
-    decoyPenaltyMs: 1200,
-  },
-  {
-    id: 3, label: '關卡 3 · 群魔亂舞',
-    duration: 11, requiredHits: 5,
-    chaseAutoMoveInterval: 550, chaseClickCooldown: 700,
-    wrongClickCooldown: 2200,
-    sizeSearch: 36, sizeChase: 56,
-    decoyCount: 2, decoyAutoMove: true,
-    decoyPenaltyMs: 1500,
-  },
-];

--- a/src/levels.js
+++ b/src/levels.js
@@ -1,0 +1,55 @@
+// Per-level tunables. Cross-level constants stay in constants.js.
+
+export const LEVELS = [
+  {
+    id: 1,
+    name: '初次相遇',
+    duration: 15,
+    requiredHits: 3,
+    chaseAutoMoveMs: 900,
+    chaseClickCooldownMs: 500,
+    wrongClickCooldownMs: 1500,
+    littleThingSizeSearch: 44,
+    littleThingSizeChase: 72,
+    backgroundFilter: '',
+    chaseBlur: 'blur-sm',
+    decoys: 0,
+  },
+  {
+    id: 2,
+    name: '它變狡猾了',
+    duration: 14,
+    requiredHits: 4,
+    chaseAutoMoveMs: 650,
+    chaseClickCooldownMs: 550,
+    wrongClickCooldownMs: 1700,
+    littleThingSizeSearch: 38,
+    littleThingSizeChase: 60,
+    backgroundFilter: 'brightness-95',
+    chaseBlur: 'blur-md',
+    decoys: 1,
+  },
+  {
+    id: 3,
+    name: '最後一搏',
+    duration: 13,
+    requiredHits: 5,
+    chaseAutoMoveMs: 480,
+    chaseClickCooldownMs: 600,
+    wrongClickCooldownMs: 2000,
+    littleThingSizeSearch: 32,
+    littleThingSizeChase: 52,
+    backgroundFilter: 'hue-rotate-15 brightness-90',
+    chaseBlur: 'blur-lg',
+    decoys: 2,
+  },
+];
+
+export function getLevel(idx) {
+  const max = LEVELS.length - 1;
+  const clamped = Math.min(Math.max(idx | 0, 0), max);
+  return LEVELS[clamped];
+}
+
+// Dev sanity: prevent future edits from accidentally emptying the table.
+console.assert(LEVELS.length === 3, 'LEVELS must contain exactly 3 entries');


### PR DESCRIPTION
Closes #28

## Summary
Foundation task. Create src/levels.js exporting a LEVELS array of three plain objects exactly matching the PRD's Design section schema (id, name, duration, requiredHits, chaseAutoMoveMs, chaseClickCooldownMs, wrongClickCooldownMs, littleThingSizeSearch, littleThingSizeChase, backgroundFilter, chaseBlur, decoys) with the L1/L2/L3 values from the PRD. Also export a getLevel(idx) helper that clamps idx to [0, LEVELS.length-1]. Add a dev-only console.assert(LEVELS.length === 3) at module scope. In src/constants.js, REMOVE the now-redundant tunables (GAME_DURATION, REQUIRED_HITS, CHASE_AUTO_MOVE_INTERVAL, LITTLE_THING_SIZE_SEARCH, LITTLE_THING_SIZE_CHASE, CHASE_CLICK_COOLDOWN, WRONG_CLICK_COOLDOWN) and KEEP cross-level constants (SAFE_MARGIN, GAME_PHASE, ASSETS, CHASE_MOVE_DURATION, anything else not duplicated by LEVELS). Do NOT yet wire LEVELS into GameContainer.jsx — that's t-game-container's job; this task may temporarily leave the game broken because GameContainer still imports the removed constants. The next task in the chain (t-game-container) restores it. Acceptance: `npm run build` may fail at this exact commit due to deliberate constant removal — that's expected; verify by reading the diff that no other file outside src/levels.js, src/constants.js was touched, and that LEVELS literally matches the PRD table.

_Generated by stageman._
