### PR TITLE
[stageman] Refactor GameContainer for 3-level flow, decoys, HUD level chip

### DIFF
--- a/src/components/GameContainer.jsx
+++ b/src/components/GameContainer.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { Heart, Search, Timer, Play } from 'lucide-react';
 
@@ -7,18 +7,10 @@ import ProgressBar from './ProgressBar.jsx';
 import CooldownOverlay from './CooldownOverlay.jsx';
 import Confetti from './Confetti.jsx';
 import ResultModal from './ResultModal.jsx';
+import LevelTransition from './LevelTransition.jsx';
 
-import {
-  ASSETS,
-  CHASE_AUTO_MOVE_INTERVAL,
-  CHASE_CLICK_COOLDOWN,
-  GAME_DURATION,
-  GAME_PHASE,
-  LITTLE_THING_SIZE_CHASE,
-  LITTLE_THING_SIZE_SEARCH,
-  REQUIRED_HITS,
-  WRONG_CLICK_COOLDOWN,
-} from '../constants.js';
+import { ASSETS, GAME_PHASE } from '../constants.js';
+import { LEVELS } from '../levels.js';
 import {
   getRandomPosition,
   getRandomPositionAwayFrom,
@@ -26,13 +18,15 @@ import {
 
 // ============================================================
 // GameContainer：整個遊戲的大腦
-// 負責遊戲階段切換、倒數、冷卻、命中判定與 UI 呈現。
+// 三關連續挑戰；負責 FSM、倒數、冷卻、命中判定、假目標與 UI 呈現。
 // ============================================================
 export default function GameContainer() {
   // ---------- 基礎狀態 ----------
   const [phase, setPhase] = useState(GAME_PHASE.IDLE);
   const [hits, setHits] = useState(0); // 追逐期已命中次數
-  const [timeLeft, setTimeLeft] = useState(GAME_DURATION); // 秒
+  const [levelIndex, setLevelIndex] = useState(0);
+  const level = LEVELS[levelIndex];
+  const [timeLeft, setTimeLeft] = useState(level.duration); // 秒
 
   // 搜尋期「點錯」冷卻
   const [wrongCooldown, setWrongCooldown] = useState(false);
@@ -44,6 +38,10 @@ export default function GameContainer() {
   // 小東西位置（以容器像素計算）
   const [position, setPosition] = useState({ x: 0, y: 0 });
 
+  // 假目標：position 列表 + L3 真目標暫時偽裝為 decoy
+  const [decoyPositions, setDecoyPositions] = useState([]); // [{id, x, y}]
+  const [isFakingDecoy, setIsFakingDecoy] = useState(false);
+
   // ---------- Ref ----------
   const containerRef = useRef(null);
   const containerSizeRef = useRef({ w: 0, h: 0 });
@@ -52,15 +50,10 @@ export default function GameContainer() {
   const chaseCooldownTimerRef = useRef(null);
   const autoMoveTimerRef = useRef(null);
   const countdownTimerRef = useRef(null);
-
-  // ---------- 工具：取得目前小東西尺寸 ----------
-  const currentSize = useMemo(
-    () =>
-      phase === GAME_PHASE.CHASING
-        ? LITTLE_THING_SIZE_CHASE
-        : LITTLE_THING_SIZE_SEARCH,
-    [phase]
-  );
+  const levelTransitionTimerRef = useRef(null);
+  const fakeDecoyTimerRef = useRef(null);
+  const fakeDecoyInnerRef = useRef(null);
+  const tickCounterRef = useRef(0);
 
   // ---------- 工具：重新量測容器尺寸 ----------
   const measure = useCallback(() => {
@@ -70,19 +63,6 @@ export default function GameContainer() {
     return containerSizeRef.current;
   }, []);
 
-  // ---------- 工具：放置小東西到新位置 ----------
-  const relocate = useCallback(
-    (awayFromCurrent = false) => {
-      const { w, h } = containerSizeRef.current;
-      if (w === 0 || h === 0) return;
-      const next = awayFromCurrent
-        ? getRandomPositionAwayFrom(w, h, currentSize, position)
-        : getRandomPosition(w, h, currentSize);
-      setPosition(next);
-    },
-    [currentSize, position]
-  );
-
   // ---------- 清除所有計時器 ----------
   const clearAllTimers = useCallback(() => {
     clearTimeout(wrongCooldownTimerRef.current);
@@ -90,31 +70,47 @@ export default function GameContainer() {
     clearTimeout(chaseCooldownTimerRef.current);
     clearInterval(autoMoveTimerRef.current);
     clearInterval(countdownTimerRef.current);
+    clearTimeout(levelTransitionTimerRef.current);
+    clearInterval(fakeDecoyTimerRef.current);
+    clearTimeout(fakeDecoyInnerRef.current);
     wrongCooldownTimerRef.current = null;
     wrongCooldownRafRef.current = null;
     chaseCooldownTimerRef.current = null;
     autoMoveTimerRef.current = null;
     countdownTimerRef.current = null;
+    levelTransitionTimerRef.current = null;
+    fakeDecoyTimerRef.current = null;
+    fakeDecoyInnerRef.current = null;
+    tickCounterRef.current = 0;
   }, []);
 
-  // ---------- 開始遊戲 ----------
-  const startGame = useCallback(() => {
-    clearAllTimers();
-    setHits(0);
-    setTimeLeft(GAME_DURATION);
-    setWrongCooldown(false);
-    setWrongCooldownProgress(0);
-    setChaseClickCooldown(false);
-    setPhase(GAME_PHASE.SEARCHING);
+  // ---------- 進入指定關卡 ----------
+  const enterLevel = useCallback(
+    (idx) => {
+      clearAllTimers();
+      const lvl = LEVELS[idx];
+      setHits(0);
+      setTimeLeft(lvl.duration);
+      setWrongCooldown(false);
+      setWrongCooldownProgress(0);
+      setChaseClickCooldown(false);
+      setIsFakingDecoy(false);
+      setDecoyPositions([]);
+      setLevelIndex(idx);
+      setPhase(GAME_PHASE.SEARCHING);
 
-    // 首次隨機定位
-    requestAnimationFrame(() => {
-      const { w, h } = measure();
-      if (w && h) {
-        setPosition(getRandomPosition(w, h, LITTLE_THING_SIZE_SEARCH));
-      }
-    });
-  }, [clearAllTimers, measure]);
+      requestAnimationFrame(() => {
+        const { w, h } = measure();
+        if (w && h) {
+          setPosition(getRandomPosition(w, h, lvl.littleThingSizeSearch));
+        }
+      });
+    },
+    [clearAllTimers, measure]
+  );
+
+  // ---------- 開始遊戲（從 L1） ----------
+  const startGame = useCallback(() => enterLevel(0), [enterLevel]);
 
   // ---------- 全域倒數 ----------
   useEffect(() => {
@@ -146,19 +142,52 @@ export default function GameContainer() {
     }
   }, [timeLeft, phase, clearAllTimers]);
 
-  // ---------- 追逐期：每隔一段時間自動逃竄 ----------
+  // ---------- 追逐期：統一 tick 自動逃竄（真目標 + 假目標 1.4 倍週期） ----------
   useEffect(() => {
     if (phase !== GAME_PHASE.CHASING) return undefined;
+    tickCounterRef.current = 0;
     autoMoveTimerRef.current = setInterval(() => {
       const { w, h } = containerSizeRef.current;
       if (!w || !h) return;
+      tickCounterRef.current += 1;
+
       setPosition((prev) =>
-        getRandomPositionAwayFrom(w, h, LITTLE_THING_SIZE_CHASE, prev)
+        getRandomPositionAwayFrom(w, h, level.littleThingSizeChase, prev)
       );
-    }, CHASE_AUTO_MOVE_INTERVAL);
+
+      // 假目標移動：每 7 tick 動 5 次（平均週期 1.4×）。
+      if ((tickCounterRef.current * 5) % 7 < 5) {
+        setDecoyPositions((prev) =>
+          prev.map((d) => {
+            const next = getRandomPositionAwayFrom(
+              w,
+              h,
+              level.littleThingSizeChase,
+              d,
+              0.2
+            );
+            return { ...d, ...next };
+          })
+        );
+      }
+    }, level.chaseAutoMoveMs);
 
     return () => clearInterval(autoMoveTimerRef.current);
-  }, [phase]);
+  }, [phase, level.chaseAutoMoveMs, level.littleThingSizeChase]);
+
+  // ---------- L3：真目標短暫卸下光環，混入假目標群 ----------
+  useEffect(() => {
+    if (phase !== GAME_PHASE.CHASING) return undefined;
+    if (levelIndex !== 2) return undefined;
+    fakeDecoyTimerRef.current = setInterval(() => {
+      setIsFakingDecoy(true);
+      fakeDecoyInnerRef.current = setTimeout(() => setIsFakingDecoy(false), 400);
+    }, 2500);
+    return () => {
+      clearInterval(fakeDecoyTimerRef.current);
+      clearTimeout(fakeDecoyInnerRef.current);
+    };
+  }, [phase, levelIndex]);
 
   // ---------- 視窗 resize 重新量測 ----------
   useEffect(() => {
@@ -183,11 +212,10 @@ export default function GameContainer() {
     setWrongCooldown(true);
     setWrongCooldownProgress(0);
 
-    // 用 requestAnimationFrame 平滑更新進度條
     const start = performance.now();
     const tick = (now) => {
       const elapsed = now - start;
-      const ratio = Math.min(elapsed / WRONG_CLICK_COOLDOWN, 1);
+      const ratio = Math.min(elapsed / level.wrongClickCooldownMs, 1);
       setWrongCooldownProgress(ratio);
       if (ratio < 1) {
         wrongCooldownRafRef.current = requestAnimationFrame(tick);
@@ -198,8 +226,8 @@ export default function GameContainer() {
     wrongCooldownTimerRef.current = setTimeout(() => {
       setWrongCooldown(false);
       setWrongCooldownProgress(0);
-    }, WRONG_CLICK_COOLDOWN);
-  }, [phase, wrongCooldown]);
+    }, level.wrongClickCooldownMs);
+  }, [phase, wrongCooldown, level.wrongClickCooldownMs]);
 
   // ---------- 觸發追逐期「點擊後」冷卻 ----------
   const triggerChaseCooldown = useCallback(() => {
@@ -207,10 +235,32 @@ export default function GameContainer() {
     clearTimeout(chaseCooldownTimerRef.current);
     chaseCooldownTimerRef.current = setTimeout(() => {
       setChaseClickCooldown(false);
-    }, CHASE_CLICK_COOLDOWN);
+    }, level.chaseClickCooldownMs);
+  }, [level.chaseClickCooldownMs]);
+
+  // ---------- 假目標多錨點配置 ----------
+  const placeDecoys = useCallback((targetPos, count, w, h, size) => {
+    const out = [];
+    const minDist = w * 0.25;
+    for (let i = 0; i < count; i += 1) {
+      let candidate = getRandomPosition(w, h, size);
+      let attempts = 0;
+      while (attempts < 12) {
+        const farFromTarget =
+          Math.hypot(candidate.x - targetPos.x, candidate.y - targetPos.y) >= minDist;
+        const farFromOthers = out.every(
+          (d) => Math.hypot(candidate.x - d.x, candidate.y - d.y) >= minDist
+        );
+        if (farFromTarget && farFromOthers) break;
+        candidate = getRandomPosition(w, h, size);
+        attempts += 1;
+      }
+      out.push({ id: i, ...candidate });
+    }
+    return out;
   }, []);
 
-  // ---------- 點中小東西處理 ----------
+  // ---------- 點中真目標處理 ----------
   const handleHit = useCallback(() => {
     if (phase === GAME_PHASE.SEARCHING) {
       // 搜尋期 → 進入追逐期
@@ -220,19 +270,24 @@ export default function GameContainer() {
       setWrongCooldownProgress(0);
 
       setPhase(GAME_PHASE.CHASING);
-      setHits(0); // 追逐期從 0/REQUIRED_HITS 開始
+      setHits(0);
 
-      // 換一個更大尺寸的新位置
       requestAnimationFrame(() => {
         const { w, h } = containerSizeRef.current;
         if (w && h) {
-          setPosition(
-            getRandomPositionAwayFrom(w, h, LITTLE_THING_SIZE_CHASE, position)
+          const target = getRandomPositionAwayFrom(
+            w,
+            h,
+            level.littleThingSizeChase,
+            position
+          );
+          setPosition(target);
+          setDecoyPositions(
+            placeDecoys(target, level.decoys, w, h, level.littleThingSizeChase)
           );
         }
       });
 
-      // 命中後短冷卻（給使用者反應時間）
       triggerChaseCooldown();
       return;
     }
@@ -242,25 +297,66 @@ export default function GameContainer() {
 
       setHits((prev) => {
         const next = prev + 1;
-        if (next >= REQUIRED_HITS) {
+        if (next >= level.requiredHits) {
           clearAllTimers();
-          setPhase(GAME_PHASE.WIN);
+          if (levelIndex === LEVELS.length - 1) {
+            setPhase(GAME_PHASE.WIN);
+          } else {
+            setPhase(GAME_PHASE.LEVEL_TRANSITION);
+            levelTransitionTimerRef.current = setTimeout(() => {
+              enterLevel(levelIndex + 1);
+            }, 1200);
+          }
         }
         return next;
       });
 
-      // 立刻逃竄到新位置
       const { w, h } = containerSizeRef.current;
       if (w && h) {
         setPosition((prev) =>
-          getRandomPositionAwayFrom(w, h, LITTLE_THING_SIZE_CHASE, prev, 0.3)
+          getRandomPositionAwayFrom(w, h, level.littleThingSizeChase, prev, 0.3)
         );
       }
 
       triggerChaseCooldown();
     }
-    // 其他階段（IDLE/WIN/LOSE）忽略
-  }, [phase, position, chaseClickCooldown, clearAllTimers, triggerChaseCooldown]);
+    // 其他階段（IDLE/LEVEL_TRANSITION/WIN/LOSE）忽略
+  }, [
+    phase,
+    position,
+    chaseClickCooldown,
+    clearAllTimers,
+    triggerChaseCooldown,
+    level.littleThingSizeChase,
+    level.requiredHits,
+    level.decoys,
+    levelIndex,
+    enterLevel,
+    placeDecoys,
+  ]);
+
+  // ---------- 點到假目標處理 ----------
+  const handleDecoyHit = useCallback(() => {
+    if (chaseClickCooldown || wrongCooldown) return;
+    // 罰時 -1.5s（不會低於 0；timeLeft===0 由現有 effect 觸發 LOSE）
+    setTimeLeft((t) => Math.max(0, t - 1.5));
+
+    // 重用點錯紅條視覺
+    setWrongCooldown(true);
+    setWrongCooldownProgress(0);
+    const start = performance.now();
+    const tick = (now) => {
+      const ratio = Math.min((now - start) / level.wrongClickCooldownMs, 1);
+      setWrongCooldownProgress(ratio);
+      if (ratio < 1) wrongCooldownRafRef.current = requestAnimationFrame(tick);
+    };
+    wrongCooldownRafRef.current = requestAnimationFrame(tick);
+    wrongCooldownTimerRef.current = setTimeout(() => {
+      setWrongCooldown(false);
+      setWrongCooldownProgress(0);
+    }, level.wrongClickCooldownMs);
+    // 注意：不增加 hits
+  }, [chaseClickCooldown, wrongCooldown, level.wrongClickCooldownMs]);
 
   // ---------- 衍生狀態 ----------
   const isPlaying =
@@ -278,26 +374,32 @@ export default function GameContainer() {
       className="relative h-[100dvh] w-full overflow-hidden select-none"
       style={{ touchAction: 'manipulation' }}
     >
-      {/* 背景圖：👉 替換 ASSETS.BACKGROUND 為你的背景圖 */}
+      {/* 背景圖：每關套用不同 filter / blur */}
       <div
         className={`absolute inset-0 bg-cover bg-center transition-[filter] duration-500 ${
-          isChasing ? 'blur-sm brightness-90' : ''
+          isChasing ? level.chaseBlur : level.backgroundFilter
         }`}
         style={{ backgroundImage: `url(${ASSETS.BACKGROUND})` }}
       />
-      {/* 半透明壓暗，讓 UI 與小東西更清楚 */}
       <div className="absolute inset-0 bg-black/10" />
 
       {/* ---------- 頂部 HUD ---------- */}
       <div className="pointer-events-none absolute inset-x-0 top-0 z-30 flex flex-col gap-2 px-4 pt-[calc(env(safe-area-inset-top)+12px)]">
         <div className="flex items-center justify-between text-white drop-shadow">
-          <div className="flex items-center gap-1 rounded-full bg-black/45 px-3 py-1 text-sm font-semibold backdrop-blur">
-            {isChasing ? (
-              <Heart className="h-4 w-4 text-rose-400" />
-            ) : (
-              <Search className="h-4 w-4 text-sky-300" />
-            )}
-            <span>{isChasing ? '追逐期' : '搜尋期'}</span>
+          <div className="flex items-center gap-2">
+            <div className="flex items-center gap-1 rounded-full bg-black/45 px-3 py-1 text-sm font-semibold backdrop-blur">
+              <span>
+                Level {levelIndex + 1}/{LEVELS.length}
+              </span>
+            </div>
+            <div className="flex items-center gap-1 rounded-full bg-black/45 px-3 py-1 text-sm font-semibold backdrop-blur">
+              {isChasing ? (
+                <Heart className="h-4 w-4 text-rose-400" />
+              ) : (
+                <Search className="h-4 w-4 text-sky-300" />
+              )}
+              <span>{isChasing ? '追逐期' : '搜尋期'}</span>
+            </div>
           </div>
           <div className="flex items-center gap-1 rounded-full bg-black/45 px-3 py-1 text-sm font-semibold backdrop-blur">
             <Timer className="h-4 w-4 text-amber-300" />
@@ -305,7 +407,7 @@ export default function GameContainer() {
           </div>
         </div>
 
-        {/* 進度條：搜尋期顯示冷卻、追逐期顯示血量（剩餘命中） */}
+        {/* 進度條 */}
         {isPlaying && (
           <div className="mt-1">
             {!isChasing ? (
@@ -318,8 +420,8 @@ export default function GameContainer() {
             ) : (
               <ProgressBar
                 label="小東西血量"
-                value={REQUIRED_HITS - hits}
-                max={REQUIRED_HITS}
+                value={level.requiredHits - hits}
+                max={level.requiredHits}
                 color="bg-gradient-to-r from-emerald-400 to-lime-300"
               />
             )}
@@ -327,21 +429,47 @@ export default function GameContainer() {
         )}
       </div>
 
-      {/* ---------- 小東西 ---------- */}
+      {/* ---------- 真目標 ---------- */}
       {isPlaying && (
         <LittleThing
           phase={isChasing ? 'chasing' : 'searching'}
           position={position}
           clickable={!chaseClickCooldown && !wrongCooldown}
+          isDecoy={isFakingDecoy}
           onHit={handleHit}
         />
       )}
+
+      {/* ---------- 假目標 ---------- */}
+      {isPlaying &&
+        isChasing &&
+        decoyPositions.map((d) => (
+          <LittleThing
+            key={`decoy-${d.id}`}
+            phase="chasing"
+            position={{ x: d.x, y: d.y }}
+            clickable={!chaseClickCooldown && !wrongCooldown}
+            isDecoy
+            onHit={handleDecoyHit}
+          />
+        ))}
 
       {/* ---------- 點錯冷卻遮罩 ---------- */}
       <CooldownOverlay active={wrongCooldown} />
 
       {/* ---------- 勝利彩帶 ---------- */}
       {phase === GAME_PHASE.WIN && <Confetti count={90} />}
+
+      {/* ---------- 關卡切換動畫 ---------- */}
+      <AnimatePresence>
+        {phase === GAME_PHASE.LEVEL_TRANSITION &&
+          levelIndex + 1 < LEVELS.length && (
+            <LevelTransition
+              levelNumber={levelIndex + 2}
+              levelName={LEVELS[levelIndex + 1].name}
+            />
+          )}
+      </AnimatePresence>
 
       {/* ---------- 開始畫面 ---------- */}
       <AnimatePresence>
@@ -366,9 +494,7 @@ export default function GameContainer() {
               animate={{ opacity: 1 }}
               transition={{ delay: 0.25 }}
             >
-              在畫面中找出藏起來的小東西，點中後要在 {GAME_DURATION} 秒內
-              <br />
-              再追著點中 {REQUIRED_HITS} 下才算贏！
+              3 關連續挑戰，難度逐關上升 — 中途失敗整場重來。
             </motion.p>
 
             <motion.button
@@ -390,6 +516,7 @@ export default function GameContainer() {
       <ResultModal
         open={showResult}
         result={phase === GAME_PHASE.WIN ? 'win' : 'lose'}
+        clearedFinalLevel={phase === GAME_PHASE.WIN}
         onRestart={startGame}
       />
     </div>

--- a/src/components/ResultModal.jsx
+++ b/src/components/ResultModal.jsx
@@ -8,9 +8,10 @@ import { PartyPopper, RotateCcw, Heart, Frown } from 'lucide-react';
  * @param {object} props
  * @param {boolean} props.open
  * @param {'win'|'lose'} props.result
+ * @param {boolean} [props.clearedFinalLevel]  是否通關最後一關（決定勝利文案）
  * @param {() => void} props.onRestart
  */
-export default function ResultModal({ open, result, onRestart }) {
+export default function ResultModal({ open, result, clearedFinalLevel = false, onRestart }) {
   const isWin = result === 'win';
 
   return (
@@ -56,7 +57,9 @@ export default function ResultModal({ open, result, onRestart }) {
             </h2>
             <p className="mb-6 text-base leading-relaxed">
               {isWin
-                ? '週末請妳吃壽司大餐！🍣'
+                ? clearedFinalLevel
+                  ? '週末請妳吃壽司大餐！🍣'
+                  : '下次再來挑戰！'
                 : '這次讓它溜走了，再挑戰一次吧！'}
             </p>
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -32,6 +32,7 @@ export const GAME_PHASE = {
   IDLE: 'idle',
   SEARCHING: 'searching',
   CHASING: 'chasing',
+  LEVEL_TRANSITION: 'level_transition',
   WIN: 'win',
   LOSE: 'lose',
 };


### PR DESCRIPTION
Closes #31

## Summary
Core integration task. Refactor src/components/GameContainer.jsx to drive the three-level loop and decoy mechanic from LEVELS:

1. Replace direct constants.js reads (GAME_DURATION, REQUIRED_HITS, CHASE_AUTO_MOVE_INTERVAL, LITTLE_THING_SIZE_*, CHASE_CLICK_COOLDOWN, WRONG_CLICK_COOLDOWN) with `LEVELS[levelIndex].*` reads. Import LEVELS from src/levels.js.
2. Add state: `levelIndex` (0|1|2, initial 0) and `decoyPositions: Array<{x,y,id}>`. Reset both on game restart so a re-play after WIN/LOSE goes back to L1.
3. Add a new GAME_PHASE.LEVEL_TRANSITION value in src/constants.js's GAME_PHASE enum. When `hits >= LEVELS[levelIndex].requiredHits` inside chase phase: clearAllTimers, set phase to LEVEL_TRANSITION, mount LevelTransition (from t-level-transition) with levelNumber/levelName for the NEXT level, and set a single setTimeout(1.2s) that increments levelIndex and re-runs the existing startGame initialization (search phase, fresh duration, fresh decoys). If `levelIndex === 2` at clear-time, skip the transition and go straight to WIN (existing Confetti + ResultModal path).
4. In chase phase for levels with `decoys > 0`, render N additional <LittleThing isDecoy /> instances using decoyPositions. Initial placement: extend src/utils/random.js's getRandomPositionAwayFrom (or wrap it in GameContainer) with a retry loop (max 12 attempts) requiring distance >= 0.25 * containerWidth from the real target AND from every prior decoy; on retry exhaustion, accept the last candidate. Click on a decoy: subtract 1.5s from the countdown, trigger the existing wrongCooldown red-bar visual, do NOT increment hits.
5. Auto-flee tick: keep a single interval at `LEVELS[levelIndex].chaseAutoMoveMs`; on tick, move the real target as today, and move each decoy (use period chaseAutoMoveMs * 1.4 by counting ticks per decoy rather than spawning extra intervals).
6. HUD: add a `Level {levelIndex+1}/3` chip next to the existing 搜尋期/追逐期 chip near GameContainer.jsx:294, using the same `bg-black/45 rounded-full` style.
7. Apply `LEVELS[levelIndex].backgroundFilter` to the search-phase background container, and `chaseBlur` to the chase-phase background, replacing any hardcoded blur classes.
8. L3-only quality mechanic: PRD Open Question #3 was approved but did not pick a specific option. Commit to the lighter of the two PRD-listed options — 'real target briefly drops its yellow halo every ~2.5s for ~0.4s' — implemented by toggling an `isFakingDecoy` boolean state on a setInterval guarded by `levelIndex === 2`. Pass `isDecoy={isFakingDecoy}` to the real LittleThing only during these windows. (Reviewer can override at Approve gate; the alternative is a 0.3s black overlay flash.)
9. Failure: any level's countdown hitting 0 → LOSE immediately (no continues), restart resets levelIndex to 0.
10. Update src/components/ResultModal.jsx so the WIN message only renders the sushi line when the player just cleared L3 (pass a `clearedFinalLevel` boolean from GameContainer). LOSE message unchanged.

Also add GAME_PHASE.LEVEL_TRANSITION to constants.js's GAME_PHASE export. Manual verification per the PRD Test Plan (L1→L2 transition card visible, decoy click penalty, L3 background blur visible, replay returns to L1, mobile 320px/414px decoy non-overlap).

_Generated by stageman._
